### PR TITLE
JI-5468 — Start Over: Cornell Notes

### DIFF
--- a/src/scripts/h5p-cornell-content.js
+++ b/src/scripts/h5p-cornell-content.js
@@ -26,7 +26,7 @@ export default class CornellContent {
     // Create values to fill with
     this.previousState = Util.extend(
       {
-        dateString: '',
+        dateString: new Date().toLocaleDateString(),
         recall: { inputField: '' },
         mainNotes: { inputField: '' },
         summary: { inputField: '' }
@@ -358,14 +358,22 @@ export default class CornellContent {
   /**
    * Get current state to be saved.
    * @returns {object} Current state.
+   *
    */
   getCurrentState() {
+    console.log('test')
+    /*
+     * H5P integrations may (for instance) show a restart button if there is
+     * a previous state set, so here not storing the state if no answer has been
+     * given by the user and there's no order stored previously - preventing
+     * to show up that restart button without the need to.
+     */
     if (!this.getAnswerGiven()) {
       return;
     }
 
     return {
-      dateString: new Date().toLocaleDateString(),
+      dateString: this.previousState.dateString,
       recall: this.stripTags(this.recall.getCurrentState()),
       mainNotes: this.stripTags(this.mainNotes.getCurrentState()),
       summary: this.stripTags(this.summary.getCurrentState()),

--- a/src/scripts/h5p-cornell-content.js
+++ b/src/scripts/h5p-cornell-content.js
@@ -358,10 +358,8 @@ export default class CornellContent {
   /**
    * Get current state to be saved.
    * @returns {object} Current state.
-   *
    */
   getCurrentState() {
-    console.log('test')
     /*
      * H5P integrations may (for instance) show a restart button if there is
      * a previous state set, so here not storing the state if no answer has been

--- a/src/scripts/h5p-cornell-content.js
+++ b/src/scripts/h5p-cornell-content.js
@@ -26,7 +26,7 @@ export default class CornellContent {
     // Create values to fill with
     this.previousState = Util.extend(
       {
-        dateString: new Date().toLocaleDateString(),
+        dateString: '',
         recall: { inputField: '' },
         mainNotes: { inputField: '' },
         summary: { inputField: '' }
@@ -360,8 +360,12 @@ export default class CornellContent {
    * @returns {object} Current state.
    */
   getCurrentState() {
+    if (!this.getAnswerGiven()) {
+      return;
+    }
+
     return {
-      dateString: this.previousState.dateString,
+      dateString: new Date().toLocaleDateString(),
       recall: this.stripTags(this.recall.getCurrentState()),
       mainNotes: this.stripTags(this.mainNotes.getCurrentState()),
       summary: this.stripTags(this.summary.getCurrentState()),

--- a/src/scripts/h5p-cornell-content.js
+++ b/src/scripts/h5p-cornell-content.js
@@ -366,12 +366,8 @@ export default class CornellContent {
      * given by the user and there's no order stored previously - preventing
      * to show up that restart button without the need to.
      */
-    if (!this.getAnswerGiven()) {
-      return;
-    }
-
     return {
-      dateString: this.previousState.dateString,
+      dateString: this.getAnswerGiven() ? this.previousState.dateString : undefined,
       recall: this.stripTags(this.recall.getCurrentState()),
       mainNotes: this.stripTags(this.mainNotes.getCurrentState()),
       summary: this.stripTags(this.summary.getCurrentState()),


### PR DESCRIPTION
So when user refresh / leave and comes back later without interacting after creating a cornell content, they don't see the attempt bar and Start Over button.