### PR TITLE
Remove comment

### DIFF
--- a/src/scripts/h5p-cornell-content.js
+++ b/src/scripts/h5p-cornell-content.js
@@ -360,12 +360,6 @@ export default class CornellContent {
    * @returns {object} Current state.
    */
   getCurrentState() {
-    /*
-     * H5P integrations may (for instance) show a restart button if there is
-     * a previous state set, so here not storing the state if no answer has been
-     * given by the user and there's no order stored previously - preventing
-     * to show up that restart button without the need to.
-     */
     return {
       dateString: this.getAnswerGiven() ? this.previousState.dateString : undefined,
       recall: this.stripTags(this.recall.getCurrentState()),


### PR DESCRIPTION
I find this comment confusing. It doesn't seem to reflect what is in fact returned at this point (left over from before changes were made?).

The context that is being described can also be referenced now in the official docs at https://h5p.org/documentation/developers/contracts#guides-header-7.

Do you think we could just remove it? 